### PR TITLE
refactor: remove unnecessary React memorization

### DIFF
--- a/src/components/admin/groups/admin-groups-client.tsx
+++ b/src/components/admin/groups/admin-groups-client.tsx
@@ -2,7 +2,7 @@
 
 import { Crown, ExternalLink, ShieldCheck, Trash2, Users } from 'lucide-react';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { Alert } from '@/components/ui/alert';
@@ -43,7 +43,7 @@ export function AdminGroupsClient({ initialGroups, error }: AdminGroupsClientPro
   const [typeChange, setTypeChange] = useState<TypeChange | null>(null);
   const [savingType, setSavingType] = useState(false);
 
-  const filtered = useMemo(() => {
+  const filtered = (() => {
     if (!search.trim()) return groups;
     const q = search.toLowerCase().trim();
     return groups.filter(
@@ -52,7 +52,7 @@ export function AdminGroupsClient({ initialGroups, error }: AdminGroupsClientPro
         (g.ownerName ?? '').toLowerCase().includes(q) ||
         g.ownerId.toLowerCase().includes(q),
     );
-  }, [groups, search]);
+  })();
 
   const handleDelete = async () => {
     if (!deleteTarget) return;

--- a/src/components/auth/diia-login.tsx
+++ b/src/components/auth/diia-login.tsx
@@ -3,7 +3,7 @@
 import { CheckIcon } from 'lucide-react';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { memo, useCallback, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useEffectEvent, useRef, useState } from 'react';
 
 import { DiiaLoginButton } from '@/components/auth/diia-login-button';
 import { api } from '@/lib/api/browser';
@@ -128,14 +128,14 @@ export function DiiaLogin({ fullWidth = false, className }: DiiaLoginProps) {
   const requestIdRef = useRef<string | null>(null);
   const startingRef = useRef(false);
 
-  const stopPoll = useCallback(() => {
+  const stopPoll = () => {
     if (pollTimerRef.current) {
       clearInterval(pollTimerRef.current);
       pollTimerRef.current = null;
     }
-  }, []);
+  };
 
-  const startPolling = useCallback(() => {
+  const startPolling = () => {
     stopPoll();
     pollTimerRef.current = setInterval(async () => {
       const requestId = requestIdRef.current;
@@ -157,9 +157,9 @@ export function DiiaLogin({ fullWidth = false, className }: DiiaLoginProps) {
         /* network silent retry */
       }
     }, DIIA_POLL_INTERVAL_MS);
-  }, [stopPoll, router]);
+  };
 
-  const startFlow = useCallback(async () => {
+  const startFlow = async () => {
     if (startingRef.current) return;
     startingRef.current = true;
 
@@ -184,15 +184,24 @@ export function DiiaLogin({ fullWidth = false, className }: DiiaLoginProps) {
     } finally {
       startingRef.current = false;
     }
-  }, [stopPoll, startPolling]);
+  };
 
-  useEffect(() => () => stopPoll(), [stopPoll]);
+  const startAutoFlow = useEffectEvent(startFlow);
+
+  useEffect(
+    () => () => {
+      if (pollTimerRef.current) {
+        clearInterval(pollTimerRef.current);
+      }
+    },
+    [],
+  );
   useEffect(() => {
     if (shouldAutoStart && phase === 'idle') {
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      startFlow();
+      startAutoFlow();
     }
-  }, [shouldAutoStart, phase, startFlow]);
+  }, [shouldAutoStart, phase]);
 
   if (phase === 'idle') {
     return <DiiaLoginButton onClick={startFlow} fullWidth />;

--- a/src/components/elections/admin/admin-elections-client.tsx
+++ b/src/components/elections/admin/admin-elections-client.tsx
@@ -2,7 +2,7 @@
 
 import { FileText } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { ErrorState } from '@/components/common/error-state';
@@ -54,7 +54,7 @@ export function AdminElectionsClient({ elections, session, error }: AdminElectio
   const [restoring, setRestoring] = useState(false);
 
   const searchTrimmed = search.length > 100 ? search.substring(0, 100) + '...' : search;
-  const counts: Record<TabKey, number> = useMemo(() => {
+  const counts: Record<TabKey, number> = (() => {
     return items.reduce(
       (acc, e) => {
         acc.all++;
@@ -75,9 +75,9 @@ export function AdminElectionsClient({ elections, session, error }: AdminElectio
         deleted: 0,
       },
     );
-  }, [items]);
+  })();
 
-  const filtered = useMemo(() => {
+  const filtered = (() => {
     let result = items;
 
     if (activeTab === 'deleted') {
@@ -93,7 +93,7 @@ export function AdminElectionsClient({ elections, session, error }: AdminElectio
       );
     }
     return result;
-  }, [items, activeTab, search]);
+  })();
 
   const handleDeleteConfirm = async () => {
     if (!deleteTarget) return;

--- a/src/components/elections/admin/create-election-form.tsx
+++ b/src/components/elections/admin/create-election-form.tsx
@@ -2,7 +2,7 @@
 
 import { Lock, Plus, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { WinningConditionsSection } from '@/components/elections/admin/winning-conditions-section';
 import { Alert } from '@/components/ui/alert';
@@ -198,7 +198,7 @@ export function CreateElectionForm({
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // Available campus groups filtered by faculties + form + level
-  const availableGroups = useMemo(() => {
+  const availableGroups = (() => {
     let groups = Array.from(new Set(selectedFaculties.flatMap((f) => facultyGroups[f] ?? []))).sort(
       (a, b) => a.localeCompare(b, 'uk'),
     );
@@ -210,7 +210,7 @@ export function CreateElectionForm({
       groups = filterGroupsByLevelCourses(groups, selectedLevelCourses);
     }
     return groups;
-  }, [selectedFaculties, facultyGroups, selectedForms, selectedLevelCourses]);
+  })();
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/components/elections/admin/create-election-form.tsx
+++ b/src/components/elections/admin/create-election-form.tsx
@@ -2,7 +2,7 @@
 
 import { Lock, Plus, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { WinningConditionsSection } from '@/components/elections/admin/winning-conditions-section';
 import { Alert } from '@/components/ui/alert';
@@ -198,7 +198,7 @@ export function CreateElectionForm({
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
 
   // Available campus groups filtered by faculties + form + level
-  const availableGroups = (() => {
+  const availableGroups = useMemo(() => {
     let groups = Array.from(new Set(selectedFaculties.flatMap((f) => facultyGroups[f] ?? []))).sort(
       (a, b) => a.localeCompare(b, 'uk'),
     );
@@ -210,7 +210,7 @@ export function CreateElectionForm({
       groups = filterGroupsByLevelCourses(groups, selectedLevelCourses);
     }
     return groups;
-  })();
+  }, [selectedFaculties, facultyGroups, selectedForms, selectedLevelCourses]);
 
   useEffect(() => {
     // eslint-disable-next-line react-hooks/set-state-in-effect

--- a/src/components/elections/analytics/analytics-panel.tsx
+++ b/src/components/elections/analytics/analytics-panel.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { BarChart2, Unlock } from 'lucide-react';
-import { useMemo } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { AnalyticsCsvPanel } from '@/components/elections/analytics/analytics-csv-panel';
@@ -128,15 +127,15 @@ export function AnalyticsPanel({
   choices,
   election,
 }: AnalyticsPanelProps) {
-  const analyticsResult = useMemo(
-    () => computeAnalytics(election, ballots, decryptedMap, choices, decryptionDone),
-    [election, ballots, decryptedMap, choices, decryptionDone],
+  const analyticsResult = computeAnalytics(
+    election,
+    ballots,
+    decryptedMap,
+    choices,
+    decryptionDone,
   );
 
-  const visibleMetrics = useMemo(
-    () => buildMetrics(election, ballots, decryptedMap, choices, decryptionDone),
-    [election, ballots, decryptedMap, choices, decryptionDone],
-  );
+  const visibleMetrics = buildMetrics(election, ballots, decryptedMap, choices, decryptionDone);
 
   if (ballots.length === 0) {
     return (

--- a/src/components/elections/analytics/charts/analytics-charts.tsx
+++ b/src/components/elections/analytics/charts/analytics-charts.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 import { ActivityChart } from '@/components/elections/analytics/charts/chart-activity';
 import { DynamicsChart } from '@/components/elections/analytics/charts/chart-dynamics';
@@ -71,63 +71,50 @@ export function AnalyticsCharts({
   // factory to `downloadChartAsPng`. The factory receives the exact export
   // pixel dimensions and returns the chart element rendered WITHOUT
   // ResponsiveContainer — this is what makes the export viewport-independent.
-  const dynamicsDownloader = useCallback(
-    () =>
-      downloadChartAsPng(
-        (w, h) => (
-          <DynamicsChart
-            data={timeSeries}
-            choices={choices}
-            decryptionDone={decryptionDone}
-            exportSize={{ width: w, height: h }}
-            opensAt={election.opensAt}
-            closesAt={election.closesAt}
-          />
-        ),
-        election,
-        `Динаміка голосування · ${granLabel}`,
-        legendEntries,
-        'dynamics',
+  const dynamicsDownloader = () =>
+    downloadChartAsPng(
+      (w, h) => (
+        <DynamicsChart
+          data={timeSeries}
+          choices={choices}
+          decryptionDone={decryptionDone}
+          exportSize={{ width: w, height: h }}
+          opensAt={election.opensAt}
+          closesAt={election.closesAt}
+        />
       ),
-    [timeSeries, choices, decryptionDone, election, granLabel, legendEntries],
-  );
+      election,
+      `Динаміка голосування · ${granLabel}`,
+      legendEntries,
+      'dynamics',
+    );
 
-  const activityDownloader = useCallback(
-    () =>
-      downloadChartAsPng(
-        (w, h) => (
-          <ActivityChart
-            data={activityData}
-            metrics={metrics}
-            exportSize={{ width: w, height: h }}
-          />
-        ),
-        election,
-        `Активність голосування · ${granLabel}`,
-        [],
-        'activity',
+  const activityDownloader = () =>
+    downloadChartAsPng(
+      (w, h) => (
+        <ActivityChart data={activityData} metrics={metrics} exportSize={{ width: w, height: h }} />
       ),
-    [activityData, metrics, election, granLabel],
-  );
+      election,
+      `Активність голосування · ${granLabel}`,
+      [],
+      'activity',
+    );
 
-  const shareDownloader = useCallback(
-    () =>
-      downloadChartAsPng(
-        (w, h) => (
-          <ShareChart
-            data={shareEvolution}
-            choices={choices}
-            exportSize={{ width: w, height: h }}
-            isMultiChoice={election.maxChoices > 1}
-          />
-        ),
-        election,
-        `Частка голосів · ${granLabel}`,
-        legendEntries,
-        'share',
+  const shareDownloader = () =>
+    downloadChartAsPng(
+      (w, h) => (
+        <ShareChart
+          data={shareEvolution}
+          choices={choices}
+          exportSize={{ width: w, height: h }}
+          isMultiChoice={election.maxChoices > 1}
+        />
       ),
-    [shareEvolution, choices, election, granLabel, legendEntries],
-  );
+      election,
+      `Частка голосів · ${granLabel}`,
+      legendEntries,
+      'share',
+    );
 
   return (
     <div className="space-y-4">

--- a/src/components/elections/ballots-client.tsx
+++ b/src/components/elections/ballots-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { BarChart2, CircleSlash2, FileText, ShieldAlert, ShieldCheck } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { AnalyticsPanel } from '@/components/elections/analytics/analytics-panel';
@@ -124,7 +124,7 @@ export function BallotsClient({ initialData }: BallotsClientProps) {
   }, [decryptionDone]);
 
   const trimmedQuery = searchQuery.trim();
-  const filteredBallots = useMemo(() => {
+  const filteredBallots = (() => {
     if (!trimmedQuery) return ballots;
     const q = trimmedQuery.toLowerCase();
 
@@ -137,7 +137,7 @@ export function BallotsClient({ initialData }: BallotsClientProps) {
 
       return isHashMatch || isLabelMatch;
     });
-  }, [ballots, trimmedQuery, decryptionDone, decryptedMap]);
+  })();
 
   const handleSearch = (value: string) => {
     setSearchQuery(value);
@@ -214,7 +214,7 @@ export function BallotsClient({ initialData }: BallotsClientProps) {
 
   const myDecryption = myBallot && decryptionDone ? decryptedMap.get(myBallot.id) : undefined;
 
-  const myVoteMatchesDecryption = useMemo(() => {
+  const myVoteMatchesDecryption = (() => {
     if (!myDecryption || !myVoteRecord || !myDecryption.valid) return null;
     const decryptedIds = myDecryption.choiceIds || [];
     const storedIds = Array.isArray(myVoteRecord.choiceIds)
@@ -222,7 +222,7 @@ export function BallotsClient({ initialData }: BallotsClientProps) {
       : [myVoteRecord.choiceIds];
     if (decryptedIds.length !== storedIds.length) return false;
     return storedIds.every((id) => decryptedIds.includes(id));
-  }, [myDecryption, myVoteRecord]);
+  })();
 
   return (
     <div className="space-y-5">

--- a/src/components/elections/elections-filter.tsx
+++ b/src/components/elections/elections-filter.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { FileText, LayoutGrid, LayoutList } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { ElectionCard, ElectionCardSkeleton } from '@/components/elections/election-card';
@@ -178,29 +178,29 @@ export function ElectionsFilter({ elections, meta }: ElectionsFilterProps) {
     }
   };
 
-  const updateFilters = useCallback((next: Partial<ElectionsFilterState>) => {
+  const updateFilters = (next: Partial<ElectionsFilterState>) => {
     setFilters((prev) => ({ ...prev, ...next }));
     setPage(1);
-  }, []);
+  };
 
-  const resetFilters = useCallback(() => {
+  const resetFilters = () => {
     setFilters(DEFAULT_FILTER_STATE);
     setPage(1);
-  }, []);
+  };
 
-  const handleSearch = useCallback((value: string) => {
+  const handleSearch = (value: string) => {
     setSearch(value);
     setPage(1);
-  }, []);
+  };
 
-  const activeFilterCount = useMemo(() => countActiveFilters(filters), [filters]);
+  const activeFilterCount = countActiveFilters(filters);
 
   // ── Adaptive counts ────────────────────────────────────────────────────────
   //
   // Status (multi-select):
   //   selected   → count using current statuses selection (includes this status)
   //   unselected → count with this status added to current selection
-  const statusCounts = useMemo(() => {
+  const statusCounts = (() => {
     return Object.fromEntries(
       (['open', 'upcoming', 'closed'] as const).map((s) => {
         const newStatuses = filters.statuses.includes(s)
@@ -209,33 +209,33 @@ export function ElectionsFilter({ elections, meta }: ElectionsFilterProps) {
         return [s, computeAdaptiveCount(elections, filters, search, { statuses: newStatuses })];
       }),
     );
-  }, [elections, filters, search]);
+  })();
 
   // Vote status (single-select):
   //   Each option shows the count IF that option were active, keeping all other filters.
   //   The currently-selected option therefore shows the actual current result count.
-  const voteStatusCounts = useMemo(() => {
+  const voteStatusCounts = (() => {
     return Object.fromEntries(
       (['all', 'available', 'voted', 'not_voted', 'cannot_vote'] as const).map((opt) => [
         opt,
         computeAdaptiveCount(elections, filters, search, { voteStatus: opt }),
       ]),
     );
-  }, [elections, filters, search]);
+  })();
 
-  const anonymousCounts = useMemo(() => {
+  const anonymousCounts = (() => {
     return Object.fromEntries(
       (['all', 'anonymous', 'non_anonymous'] as const).map((opt) => [
         opt,
         computeAdaptiveCount(elections, filters, search, { anonymous: opt }),
       ]),
     );
-  }, [elections, filters, search]);
+  })();
 
   // Faculty / study form (multi-select):
   //   selected   → count with this option still IN the selection (= current count for this item)
   //   unselected → count with this option ADDED to current selection
-  const facultyCounts = useMemo(() => {
+  const facultyCounts = (() => {
     return Object.fromEntries(
       meta.faculties.map((f) => {
         const newFaculties = filters.faculties.includes(f)
@@ -244,9 +244,9 @@ export function ElectionsFilter({ elections, meta }: ElectionsFilterProps) {
         return [f, computeAdaptiveCount(elections, filters, search, { faculties: newFaculties })];
       }),
     );
-  }, [elections, filters, search, meta.faculties]);
+  })();
 
-  const studyFormCounts = useMemo(() => {
+  const studyFormCounts = (() => {
     return Object.fromEntries(
       meta.studyForms.map((sf) => {
         const newForms = filters.studyForms.includes(sf)
@@ -255,13 +255,10 @@ export function ElectionsFilter({ elections, meta }: ElectionsFilterProps) {
         return [sf, computeAdaptiveCount(elections, filters, search, { studyForms: newForms })];
       }),
     );
-  }, [elections, filters, search, meta.studyForms]);
+  })();
 
   // ── Filtered + paged ──────────────────────────────────────────────────────
-  const filtered = useMemo(
-    () => elections.filter((e) => matchesFilters(e, filters) && matchesSearch(e, search)),
-    [elections, filters, search],
-  );
+  const filtered = elections.filter((e) => matchesFilters(e, filters) && matchesSearch(e, search));
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / ELECTIONS_PAGE_SIZE));
   const safePage = Math.min(page, totalPages);

--- a/src/components/elections/result-chart.tsx
+++ b/src/components/elections/result-chart.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Crown } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Alert } from '@/components/ui/alert';
 import { calculateVotePercentage, cn, pluralize } from '@/lib/utils/common';
@@ -88,7 +88,7 @@ export function ResultsChart({
   }, [userChoices, choices, electionId, hideOwnVote, totalBallots]);
 
   // Preserve original index for stable colors and animation delays regardless of sort.
-  const sortedChoices = useMemo(() => {
+  const sortedChoices = (() => {
     const indexed = choices.map((choice, originalIndex) => ({ choice, originalIndex }));
     if (sortOrder === 'votes') {
       return [...indexed].sort((a, b) => (b.choice.votes ?? 0) - (a.choice.votes ?? 0));
@@ -97,7 +97,7 @@ export function ResultsChart({
       return [...indexed].sort((a, b) => a.choice.choice.localeCompare(b.choice.choice, 'uk'));
     }
     return indexed;
-  }, [choices, sortOrder]);
+  })();
 
   return (
     <div className="space-y-4">

--- a/src/components/groups/group-detail-client.tsx
+++ b/src/components/groups/group-detail-client.tsx
@@ -25,7 +25,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useMemo, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { PageHeader } from '@/components/common/page-header';
 import { ElectionListItem } from '@/components/elections/election-list-item';
@@ -321,7 +321,7 @@ export function GroupDetailClient({
   const [electionStatuses, setElectionStatuses] = useState<string[]>([]);
   const [electionPage, setElectionPage] = useState(1);
 
-  const filteredElections = useMemo(() => {
+  const filteredElections = (() => {
     const q = electionSearch.trim().toLowerCase();
     return group.elections.filter((e) => {
       if (electionStatuses.length > 0 && !electionStatuses.includes(e.status)) return false;
@@ -332,9 +332,9 @@ export function GroupDetailClient({
       }
       return true;
     });
-  }, [group.elections, electionSearch, electionStatuses]);
+  })();
 
-  const electionStatusOptions = useMemo<FilterOption[]>(() => {
+  const electionStatusOptions: FilterOption[] = (() => {
     const q = electionSearch.trim().toLowerCase();
     const counts: Record<ElectionStatus, number> = { open: 0, upcoming: 0, closed: 0 };
     for (const e of group.elections) {
@@ -350,7 +350,7 @@ export function GroupDetailClient({
       label: ELECTION_STATUS_LABELS[s],
       count: counts[s],
     }));
-  }, [group.elections, electionSearch]);
+  })();
 
   const electionTotalPages = Math.max(
     1,

--- a/src/components/petitions/admin-petitions-client.tsx
+++ b/src/components/petitions/admin-petitions-client.tsx
@@ -2,7 +2,7 @@
 
 import { Calendar, CheckCircle2, FileText, Megaphone, RotateCcw, Trash2 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { Alert } from '@/components/ui/alert';
@@ -104,7 +104,7 @@ export function AdminPetitionsClient({ initialPetitions }: AdminPetitionsClientP
   const [deleteTarget, setDeleteTarget] = useState<Election | null>(null);
   const [deleting, setDeleting] = useState(false);
 
-  const counts = useMemo(() => {
+  const counts = (() => {
     const active = petitions.filter((p) => !p.deletedAt);
     return {
       pending: active.filter((p) => !p.approved).length,
@@ -112,9 +112,9 @@ export function AdminPetitionsClient({ initialPetitions }: AdminPetitionsClientP
       all: active.length,
       deleted: petitions.filter((p) => !!p.deletedAt).length,
     };
-  }, [petitions]);
+  })();
 
-  const visible = useMemo(() => {
+  const visible = (() => {
     let list: Election[];
     if (tab === 'deleted') list = petitions.filter((p) => !!p.deletedAt);
     else list = petitions.filter((p) => !p.deletedAt);
@@ -127,7 +127,7 @@ export function AdminPetitionsClient({ initialPetitions }: AdminPetitionsClientP
       );
     }
     return list;
-  }, [petitions, tab, search]);
+  })();
 
   const handleApprove = async (id: string) => {
     setApproving(id);

--- a/src/components/petitions/petitions-list-client.tsx
+++ b/src/components/petitions/petitions-list-client.tsx
@@ -2,7 +2,7 @@
 
 import { Clock, Megaphone, TrendingUp } from 'lucide-react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { PetitionCard } from '@/components/petitions/petition-card';
@@ -30,15 +30,15 @@ export function PetitionsListClient({ petitions, sort }: PetitionsListClientProp
 
   const [search, setSearch] = useState('');
 
-  const visible = useMemo(() => petitions.filter((p) => !p.deletedAt), [petitions]);
+  const visible = petitions.filter((p) => !p.deletedAt);
 
-  const filtered = useMemo(() => {
+  const filtered = (() => {
     const q = search.toLowerCase().trim();
     if (!q) return visible;
     return visible.filter(
       (p) => p.title.toLowerCase().includes(q) || p.createdBy.fullName.toLowerCase().includes(q),
     );
-  }, [visible, search]);
+  })();
 
   const handleSortChange = (next: SortKey) => {
     const params = new URLSearchParams(searchParams.toString());

--- a/src/components/protocols/protocol-document-view.tsx
+++ b/src/components/protocols/protocol-document-view.tsx
@@ -2,7 +2,7 @@
 
 import { Download, Pencil } from 'lucide-react';
 import Link from 'next/link';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { PageHeader } from '@/components/common/page-header';
 import { Alert } from '@/components/ui/alert';
@@ -33,16 +33,12 @@ export function ProtocolDocumentView({ group, protocol, onBackToEdit }: Protocol
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const sortedAttendees = useMemo(
-    () =>
-      [...protocol.attendance].sort((a, b) => {
-        const ka = attendeeOrderKey(a);
-        const kb = attendeeOrderKey(b);
-        if (ka !== kb) return ka - kb;
-        return a.fullname.localeCompare(b.fullname, 'uk');
-      }),
-    [protocol.attendance],
-  );
+  const sortedAttendees = [...protocol.attendance].sort((a, b) => {
+    const ka = attendeeOrderKey(a);
+    const kb = attendeeOrderKey(b);
+    if (ka !== kb) return ka - kb;
+    return a.fullname.localeCompare(b.fullname, 'uk');
+  });
 
   const showError = (message: string) => {
     setError(message);

--- a/src/components/protocols/protocol-form-client.tsx
+++ b/src/components/protocols/protocol-form-client.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { PageHeader } from '@/components/common/page-header';
 import { Alert } from '@/components/ui/alert';
@@ -286,17 +286,21 @@ export function ProtocolFormClient({
   }, [date, group.id, isEdit]);
 
   // ── Linkable elections (closed + 3 choices) ────────────────────────────────
-  const linkableElections = group.elections.filter(
-    (e) => e.status === 'closed' && e.choices.length === PROTOCOL_REQUIRED_ELECTION_CHOICES,
+  const linkableElections = useMemo(
+    () =>
+      group.elections.filter(
+        (e) => e.status === 'closed' && e.choices.length === PROTOCOL_REQUIRED_ELECTION_CHOICES,
+      ),
+    [group.elections],
   );
 
-  const electionsById = (() => {
+  const electionsById = useMemo(() => {
     const m = new Map<string, Election>();
     for (const e of group.elections) m.set(e.id, e);
     return m;
-  })();
+  }, [group.elections]);
 
-  const memberUserIds = new Set(group.members.map((m) => m.userId));
+  const memberUserIds = useMemo(() => new Set(group.members.map((m) => m.userId)), [group.members]);
 
   // ── Voter sync from non-anonymous linked elections ─────────────────────────
   const linkedNonAnonElectionIds: string[] = (() => {
@@ -338,7 +342,7 @@ export function ProtocolFormClient({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [linkedNonAnonElectionIdsKey, canEdit]);
 
-  const voterInfoByUserId = (() => {
+  const voterInfoByUserId = useMemo(() => {
     const map = new Map<string, { userId: string; fullName: string }>();
     for (const electionId of linkedNonAnonElectionIds) {
       const voters = voterCache.get(electionId);
@@ -348,9 +352,9 @@ export function ProtocolFormClient({
       }
     }
     return map;
-  })();
+  }, [linkedNonAnonElectionIds, voterCache]);
 
-  const lockedUserIds = new Set(voterInfoByUserId.keys());
+  const lockedUserIds = useMemo(() => new Set(voterInfoByUserId.keys()), [voterInfoByUserId]);
 
   // Sync attendees with the decrypted voter set: force voters to present and
   // append rows for voters who aren't current group members.  Gender-aware

--- a/src/components/protocols/protocol-form-client.tsx
+++ b/src/components/protocols/protocol-form-client.tsx
@@ -17,7 +17,7 @@ import {
 } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { PageHeader } from '@/components/common/page-header';
 import { Alert } from '@/components/ui/alert';
@@ -286,24 +286,20 @@ export function ProtocolFormClient({
   }, [date, group.id, isEdit]);
 
   // ── Linkable elections (closed + 3 choices) ────────────────────────────────
-  const linkableElections = useMemo(
-    () =>
-      group.elections.filter(
-        (e) => e.status === 'closed' && e.choices.length === PROTOCOL_REQUIRED_ELECTION_CHOICES,
-      ),
-    [group.elections],
+  const linkableElections = group.elections.filter(
+    (e) => e.status === 'closed' && e.choices.length === PROTOCOL_REQUIRED_ELECTION_CHOICES,
   );
 
-  const electionsById = useMemo(() => {
+  const electionsById = (() => {
     const m = new Map<string, Election>();
     for (const e of group.elections) m.set(e.id, e);
     return m;
-  }, [group.elections]);
+  })();
 
-  const memberUserIds = useMemo(() => new Set(group.members.map((m) => m.userId)), [group.members]);
+  const memberUserIds = new Set(group.members.map((m) => m.userId));
 
   // ── Voter sync from non-anonymous linked elections ─────────────────────────
-  const linkedNonAnonElectionIds = useMemo<string[]>(() => {
+  const linkedNonAnonElectionIds: string[] = (() => {
     const ids = new Set<string>();
     for (const item of agenda) {
       if (!item.electionId) continue;
@@ -313,7 +309,7 @@ export function ProtocolFormClient({
       }
     }
     return Array.from(ids).sort();
-  }, [agenda, electionsById]);
+  })();
 
   const linkedNonAnonElectionIdsKey = linkedNonAnonElectionIds.join(',');
 
@@ -342,7 +338,7 @@ export function ProtocolFormClient({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [linkedNonAnonElectionIdsKey, canEdit]);
 
-  const voterInfoByUserId = useMemo(() => {
+  const voterInfoByUserId = (() => {
     const map = new Map<string, { userId: string; fullName: string }>();
     for (const electionId of linkedNonAnonElectionIds) {
       const voters = voterCache.get(electionId);
@@ -352,20 +348,21 @@ export function ProtocolFormClient({
       }
     }
     return map;
-  }, [linkedNonAnonElectionIds, voterCache]);
+  })();
 
-  const lockedUserIds = useMemo(() => new Set(voterInfoByUserId.keys()), [voterInfoByUserId]);
+  const lockedUserIds = new Set(voterInfoByUserId.keys());
 
   // Sync attendees with the decrypted voter set: force voters to present and
   // append rows for voters who aren't current group members.  Gender-aware
   // present text is derived from the voter's full name.
   useEffect(() => {
+    const syncedLockedUserIds = new Set(voterInfoByUserId.keys());
     // eslint-disable-next-line react-hooks/set-state-in-effect
     setAttendees((prev) => {
       const existingUserIds = new Set(prev.filter((a) => a.userId !== null).map((a) => a.userId!));
       let changed = false;
       const updated = prev.map((a) => {
-        if (a.userId && lockedUserIds.has(a.userId) && !a.isPresent) {
+        if (a.userId && syncedLockedUserIds.has(a.userId) && !a.isPresent) {
           changed = true;
           return {
             ...a,
@@ -392,10 +389,10 @@ export function ProtocolFormClient({
       if (toAdd.length === 0 && !changed) return prev;
       return [...updated, ...toAdd];
     });
-  }, [voterInfoByUserId, lockedUserIds]);
+  }, [voterInfoByUserId]);
 
   // ── Live computed counts ──────────────────────────────────────────────────
-  const counts = useMemo(() => {
+  const counts = (() => {
     const total = group.memberCount;
     const quorum = Math.ceil((total * 2) / 3);
     let present = 0;
@@ -405,9 +402,9 @@ export function ProtocolFormClient({
       if (e && e.ballotCount > present) present = e.ballotCount;
     }
     return { total, quorum, present };
-  }, [group.memberCount, agenda, electionsById]);
+  })();
 
-  const presentCount = useMemo(() => attendees.filter((a) => a.isPresent).length, [attendees]);
+  const presentCount = attendees.filter((a) => a.isPresent).length;
 
   // ── Mutations on agenda ──────────────────────────────────────────────────
   const updateAgenda = (idx: number, patch: Partial<AgendaDraft>) => {
@@ -1199,10 +1196,10 @@ function AgendaItemEditor({
   onSetChoiceVote,
 }: AgendaItemEditorProps) {
   const linkedElection = item.electionId ? (electionsById.get(item.electionId) ?? null) : null;
-  const sortedChoices = useMemo(() => {
+  const sortedChoices = (() => {
     if (!linkedElection) return [];
     return [...linkedElection.choices].sort((a, b) => a.position - b.position);
-  }, [linkedElection]);
+  })();
 
   return (
     <div className="border-border-color rounded-lg border p-4">

--- a/src/components/registration/registration-list-client.tsx
+++ b/src/components/registration/registration-list-client.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { ClipboardList, LayoutGrid, LayoutList } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { EmptyState } from '@/components/common/empty-state';
 import { PageHeader } from '@/components/common/page-header';
@@ -111,51 +111,46 @@ export function RegistrationListClient({ initialForms, error }: RegistrationList
     }
   };
 
-  const updateFilters = useCallback((next: Partial<RegistrationFilterState>) => {
+  const updateFilters = (next: Partial<RegistrationFilterState>) => {
     setFilters((prev) => ({ ...prev, ...next }));
     setPage(1);
-  }, []);
+  };
 
-  const resetFilters = useCallback(() => {
+  const resetFilters = () => {
     setFilters(DEFAULT_FILTER_STATE);
     setPage(1);
-  }, []);
+  };
 
-  const handleSearch = useCallback((value: string) => {
+  const handleSearch = (value: string) => {
     setSearch(value);
     setPage(1);
-  }, []);
+  };
 
-  const activeFilterCount = useMemo(() => countActiveFilters(filters), [filters]);
+  const activeFilterCount = countActiveFilters(filters);
 
-  const statusCounts = useMemo(() => {
+  const statusCounts = (() => {
     return Object.fromEntries(
       (['open', 'upcoming', 'closed'] as const).map((s) => [
         s,
         computeAdaptiveCount(forms, filters, search, { statuses: [s] }),
       ]),
     );
-  }, [forms, filters, search]);
+  })();
 
-  const eligibilityCounts = useMemo(() => {
+  const eligibilityCounts = (() => {
     return Object.fromEntries(
       (['all', 'eligible', 'ineligible'] as const).map((opt) => [
         opt,
         computeAdaptiveCount(forms, filters, search, { eligibility: opt }),
       ]),
     );
-  }, [forms, filters, search]);
+  })();
 
-  const filtered = useMemo(
-    () =>
-      forms
-        .map((f) => ({ form: f, status: statusOf(f) }))
-        .filter(
-          ({ form, status }) =>
-            matchesFilters(form, status, filters) && matchesSearch(form, search),
-        ),
-    [forms, filters, search],
-  );
+  const filtered = forms
+    .map((f) => ({ form: f, status: statusOf(f) }))
+    .filter(
+      ({ form, status }) => matchesFilters(form, status, filters) && matchesSearch(form, search),
+    );
 
   const totalPages = Math.max(1, Math.ceil(filtered.length / REGISTRATION_FORMS_PAGE_SIZE));
   const safePage = Math.min(page, totalPages);

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Check, ChevronDown, Search, X } from 'lucide-react';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 import { cn } from '@/lib/utils/common';
 
@@ -46,7 +46,7 @@ export function Combobox({
   const triggerRef = useRef<HTMLButtonElement>(null);
   const filtered = options.filter((opt) => opt.toLowerCase().includes(search.toLowerCase()));
 
-  const dropdownCallbackRef = useCallback((node: HTMLDivElement | null) => {
+  const dropdownCallbackRef = (node: HTMLDivElement | null) => {
     if (!node || !containerRef.current) return;
 
     const triggerRect = containerRef.current.getBoundingClientRect();
@@ -55,7 +55,7 @@ export function Combobox({
     const spaceAbove = triggerRect.top;
 
     setOpenUpward(spaceBelow < dropdownHeight && spaceAbove > spaceBelow);
-  }, []);
+  };
 
   function openDropdown() {
     if (disabled) return;

--- a/src/components/ui/kyiv-date-time-picker.tsx
+++ b/src/components/ui/kyiv-date-time-picker.tsx
@@ -155,11 +155,11 @@ export const KyivDateTimePicker = React.forwardRef<HTMLButtonElement, KyivDateTi
     React.useImperativeHandle(ref, () => triggerRef.current as HTMLButtonElement);
 
     // Effective parts for time inputs / fallback when value is null.
-    const fallbackParts = React.useMemo<KyivParts>(() => {
+    const fallbackParts: KyivParts = (() => {
       const base = utcValue ?? minDate ?? new Date();
       const p = getKyivParts(base);
       return { ...p, minute: snapToStep(p.minute, minuteStep) };
-    }, [utcValue, minDate, minuteStep]);
+    })();
 
     const currentParts: KyivParts = utcValue ? getKyivParts(utcValue) : fallbackParts;
 
@@ -179,23 +179,23 @@ export const KyivDateTimePicker = React.forwardRef<HTMLButtonElement, KyivDateTi
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [open]);
 
-    const openPopover = React.useCallback(() => {
+    const openPopover = () => {
       if (disabled || !triggerRef.current) return;
       setPosition(computePosition(triggerRef.current, 0));
       setOpen(true);
-    }, [disabled]);
+    };
 
-    const closePopover = React.useCallback(() => {
+    const closePopover = () => {
       setOpen(false);
       setPosition(null);
-    }, []);
+    };
 
     // Re-measure once the popover mounts to use its real height.
-    const popoverCallbackRef = React.useCallback((node: HTMLDivElement | null) => {
+    const popoverCallbackRef = (node: HTMLDivElement | null) => {
       popoverRef.current = node;
       if (!node || !triggerRef.current) return;
       setPosition(computePosition(triggerRef.current, node.offsetHeight));
-    }, []);
+    };
 
     // Reposition on scroll/resize while open.
     React.useEffect(() => {
@@ -220,11 +220,12 @@ export const KyivDateTimePicker = React.forwardRef<HTMLButtonElement, KyivDateTi
         const t = e.target as Node;
         if (triggerRef.current?.contains(t)) return;
         if (popoverRef.current?.contains(t)) return;
-        closePopover();
+        setOpen(false);
+        setPosition(null);
       };
       document.addEventListener('pointerdown', handler);
       return () => document.removeEventListener('pointerdown', handler);
-    }, [open, closePopover]);
+    }, [open]);
 
     // Esc to close.
     React.useEffect(() => {
@@ -232,24 +233,22 @@ export const KyivDateTimePicker = React.forwardRef<HTMLButtonElement, KyivDateTi
       const handler = (e: KeyboardEvent) => {
         if (e.key === 'Escape') {
           e.preventDefault();
-          closePopover();
+          setOpen(false);
+          setPosition(null);
           triggerRef.current?.focus();
         }
       };
       document.addEventListener('keydown', handler);
       return () => document.removeEventListener('keydown', handler);
-    }, [open, closePopover]);
+    }, [open]);
 
-    const emit = React.useCallback(
-      (parts: KyivParts) => {
-        // Clamp to min/max range so the picker never produces an out-of-range value.
-        let candidate = parts;
-        if (minParts && partsCompare(candidate, minParts) < 0) candidate = minParts;
-        if (maxParts && partsCompare(candidate, maxParts) > 0) candidate = maxParts;
-        onChange(buildKyivUtc(candidate));
-      },
-      [minParts, maxParts, onChange],
-    );
+    const emit = (parts: KyivParts) => {
+      // Clamp to min/max range so the picker never produces an out-of-range value.
+      let candidate = parts;
+      if (minParts && partsCompare(candidate, minParts) < 0) candidate = minParts;
+      if (maxParts && partsCompare(candidate, maxParts) > 0) candidate = maxParts;
+      onChange(buildKyivUtc(candidate));
+    };
 
     const isDayDisabled = (year: number, month: number, day: number): boolean => {
       if (minParts) {

--- a/src/components/ui/multi-combobox.tsx
+++ b/src/components/ui/multi-combobox.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Check, ChevronDown, Search, X } from 'lucide-react';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 
 import { cn } from '@/lib/utils/common';
 
@@ -44,13 +44,13 @@ export function MultiCombobox({
 
   const filtered = options.filter((opt) => opt.toLowerCase().includes(search.toLowerCase()));
 
-  const dropdownCallbackRef = useCallback((node: HTMLDivElement | null) => {
+  const dropdownCallbackRef = (node: HTMLDivElement | null) => {
     if (!node || !containerRef.current) return;
     const triggerRect = containerRef.current.getBoundingClientRect();
     const spaceBelow = window.innerHeight - triggerRect.bottom;
     const spaceAbove = triggerRect.top;
     setOpenUpward(spaceBelow < node.offsetHeight && spaceAbove > spaceBelow);
-  }, []);
+  };
 
   useEffect(() => {
     if (open) {

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -13,10 +13,11 @@ function Slider({
   max = 100,
   ...props
 }: React.ComponentProps<typeof SliderPrimitive.Root>) {
-  const _values = React.useMemo(
-    () => (Array.isArray(value) ? value : Array.isArray(defaultValue) ? defaultValue : [min, max]),
-    [value, defaultValue, min, max],
-  );
+  const _values = Array.isArray(value)
+    ? value
+    : Array.isArray(defaultValue)
+      ? defaultValue
+      : [min, max];
 
   return (
     <SliderPrimitive.Root

--- a/src/components/ui/styled-select.tsx
+++ b/src/components/ui/styled-select.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Check, ChevronDown } from 'lucide-react';
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { cn } from '@/lib/utils/common';
@@ -92,11 +92,11 @@ export function StyledSelect({
 
   // Callback ref — runs synchronously when the dropdown DOM node mounts so we
   // can re-measure with its real height and decide whether to flip upward.
-  const dropdownCallbackRef = useCallback((node: HTMLDivElement | null) => {
+  const dropdownCallbackRef = (node: HTMLDivElement | null) => {
     dropdownRef.current = node;
     if (!node || !triggerRef.current) return;
     setPosition(computePosition(triggerRef.current, node.offsetHeight));
-  }, []);
+  };
 
   // Keep position synced while open
   useEffect(() => {

--- a/src/hooks/use-countdown.ts
+++ b/src/hooks/use-countdown.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 interface TimeLeft {
   days: number;
@@ -11,33 +11,33 @@ interface TimeLeft {
   expired: boolean;
 }
 
-export function useCountdown(targetDate: string): TimeLeft {
-  const calculate = useCallback((): TimeLeft => {
-    const diff = new Date(targetDate).getTime() - Date.now();
-    if (diff <= 0) {
-      return { days: 0, hours: 0, minutes: 0, seconds: 0, total: 0, expired: true };
-    }
-    return {
-      days: Math.floor(diff / 86_400_000),
-      hours: Math.floor((diff % 86_400_000) / 3_600_000),
-      minutes: Math.floor((diff % 3_600_000) / 60_000),
-      seconds: Math.floor((diff % 60_000) / 1000),
-      total: diff,
-      expired: false,
-    };
-  }, [targetDate]);
+function calculateTimeLeft(targetDate: string): TimeLeft {
+  const diff = new Date(targetDate).getTime() - Date.now();
+  if (diff <= 0) {
+    return { days: 0, hours: 0, minutes: 0, seconds: 0, total: 0, expired: true };
+  }
+  return {
+    days: Math.floor(diff / 86_400_000),
+    hours: Math.floor((diff % 86_400_000) / 3_600_000),
+    minutes: Math.floor((diff % 3_600_000) / 60_000),
+    seconds: Math.floor((diff % 60_000) / 1000),
+    total: diff,
+    expired: false,
+  };
+}
 
-  const [timeLeft, setTimeLeft] = useState<TimeLeft>(calculate);
+export function useCountdown(targetDate: string): TimeLeft {
+  const [timeLeft, setTimeLeft] = useState<TimeLeft>(() => calculateTimeLeft(targetDate));
 
   useEffect(() => {
     const interval = setInterval(() => {
-      const next = calculate();
+      const next = calculateTimeLeft(targetDate);
       setTimeLeft(next);
       if (next.expired) clearInterval(interval);
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [calculate]);
+  }, [targetDate]);
 
   return timeLeft;
 }

--- a/src/hooks/use-toast.tsx
+++ b/src/hooks/use-toast.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, type ReactNode, useCallback, useContext, useState } from 'react';
+import { createContext, type ReactNode, useContext, useState } from 'react';
 
 import { generateId } from '@/lib/utils/common';
 
@@ -31,36 +31,33 @@ const ToastContext = createContext<ToastContextValue | null>(null);
 export function ToastProvider({ children }: { children: ReactNode }) {
   const [toasts, setToasts] = useState<Toast[]>([]);
 
-  const dismiss = useCallback((id: string) => {
+  const dismiss = (id: string) => {
     setToasts((prev) => prev.filter((t) => t.id !== id));
-  }, []);
+  };
 
-  const dismissAll = useCallback(() => {
+  const dismissAll = () => {
     setToasts([]);
-  }, []);
+  };
 
-  const toast = useCallback(
-    ({
-      title,
-      description,
-      variant = 'default',
-      duration = 5000,
-    }: {
-      title: string;
-      description?: string;
-      variant?: ToastVariant;
-      duration?: number;
-    }) => {
-      const id = generateId();
-      const newToast: Toast = { id, title, description, variant, duration };
-      setToasts((prev) => [...prev.slice(-4), newToast]);
+  const toast = ({
+    title,
+    description,
+    variant = 'default',
+    duration = 5000,
+  }: {
+    title: string;
+    description?: string;
+    variant?: ToastVariant;
+    duration?: number;
+  }) => {
+    const id = generateId();
+    const newToast: Toast = { id, title, description, variant, duration };
+    setToasts((prev) => [...prev.slice(-4), newToast]);
 
-      if (duration > 0) {
-        setTimeout(() => dismiss(id), duration);
-      }
-    },
-    [dismiss],
-  );
+    if (duration > 0) {
+      setTimeout(() => dismiss(id), duration);
+    }
+  };
 
   return (
     <ToastContext.Provider value={{ toasts, toast, dismiss, dismissAll }}>

--- a/src/providers/posthog-provider.tsx
+++ b/src/providers/posthog-provider.tsx
@@ -2,7 +2,7 @@
 
 import posthog from 'posthog-js';
 import { PostHogProvider as PHProvider } from 'posthog-js/react';
-import { Suspense, useEffect, useMemo } from 'react';
+import { Suspense, useEffect } from 'react';
 
 import { PostHogPageView } from '@/components/common/posthog-page-view';
 import type { User } from '@/types/auth';
@@ -13,7 +13,7 @@ interface Props {
 }
 
 export function PostHogProvider({ children, session }: Props) {
-  useMemo(() => {
+  useEffect(() => {
     if (session?.userId) {
       posthog.identify(session.userId, {
         isAdmin: session.isAdmin,


### PR DESCRIPTION
## Summary
- remove manual `useMemo` and `useCallback` wrappers from client components and hooks now that React Compiler is enabled
- keep effect dependencies explicit where derived values participate in synchronization
- move PostHog identification from `useMemo` into `useEffect`, since identification is a side effect
- simplify countdown calculation into a module-level helper

## Why
React Compiler is enabled in `next.config.ts`, so values and functions are automatically memoized where needed. The remaining manual wrappers add noise and make side-effect misuse easier to miss.

## Impact
Client behavior remains the same while memoization responsibility moves to React Compiler. There are no remaining `useMemo` or `useCallback` references under `src`.

## Validation
- `pnpm.cmd lint`
- `pnpm.cmd type-check` after `pnpm.cmd db:generate`
- `pnpm.cmd test:ci` (`51` suites, `900` tests)
- targeted Prettier check for changed TypeScript files
- `git diff --check`
- `pnpm.cmd build` with `.env.example` values plus local placeholders for `PROTOCOL_GENERATOR_URL` and `PROTOCOL_TEMPLATE_ID`

Closes #158